### PR TITLE
replace deprecated extension recommendation with its successor

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
     "recommendations": [
         "dbaeumer.vscode-eslint",
         "vue.volar",
-        "Esri.arcgis-jsapi-snippets",
+        "esri.arcgis-maps-sdk-js-snippets",
         "ctjdr.vscode-apprt-bundles"
     ]
 }


### PR DESCRIPTION
The recommended extension [ArcGIS API for JavaScript Snippets](https://marketplace.visualstudio.com/items?itemName=Esri.arcgis-jsapi-snippets) is deprecated and therefore can not be installed. This PR replaces this extension with the successor extension [ArcGIS Maps SDK for JavaScript Snippets](https://marketplace.visualstudio.com/items?itemName=Esri.arcgis-maps-sdk-js-snippets).